### PR TITLE
Fix signing_salt substitution in lib/my_app_web/endpoint.ex

### DIFF
--- a/lib/utility/project_builder.ex
+++ b/lib/utility/project_builder.ex
@@ -220,6 +220,7 @@ defmodule Utility.ProjectBuilder do
     """
     elixir --version &&
     yes n | mix phx.new #{Enum.join(flags, " ")} &&
+      shopt -s globstar &&
       (sed -i 's/secret_key_base: ".*"/secret_key_base: "foo"/g' #{where}/**/*.ex* &> /dev/null || true) &&
       (sed -i 's/signing_salt: ".*"/signing_salt: "foo"/g' #{where}/**/*.ex* &> /dev/null || true)
     """
@@ -229,6 +230,7 @@ defmodule Utility.ProjectBuilder do
     """
     elixir --version &&
     yes n | mix phx.new #{Enum.join(flags, " ")} &&
+      shopt -s globstar &&
       (sed -i 's/secret_key_base: ".*"/secret_key_base: "foo"/g' #{where}_umbrella/**/*.ex* &> /dev/null || true) &&
       (sed -i 's/signing_salt: ".*"/signing_salt: "foo"/g' #{where}_umbrella/**/*.ex* &> /dev/null || true)
     """
@@ -242,6 +244,7 @@ defmodule Utility.ProjectBuilder do
         """
         elixir --version &&
         yes n | mix phoenix.new #{Enum.join(flags, " ")} &&
+          shopt -s globstar &&
           sed -i 's/secret_key_base: ".*"/secret_key_base: "foo"/g' #{where}/**/*.ex* &&
           sed -i 's/signing_salt: ".*"/signing_salt: "foo"/g' #{where}/**/*.ex*
         """


### PR DESCRIPTION
Fixes https://github.com/zestcreative/elixirstream/issues/23

For `sed -i 's/signing_salt: ".*"/signing_salt: "foo"/g' #{where}/**/*.ex*` to replace recursively we need to [enable recursive globs](https://unix.stackexchange.com/a/49917), in bash ≥4.3 we do it by running [shopt -s globstar](https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html#The-Shopt-Builtin)

```shell
$ /usr/local/bin/docker run -it --rm diff-builder:latest /bin/bash -c 'mix archive.install --force hex phx_new 1.7.10 && mix phx.new my_app --no-install && echo "without globstar:" && ls my_app/**/*.ex* && shopt -s globstar && echo -e "\nwith globstar:" && ls my_app/**/*.ex*'

...

without globstar:
my_app/config/config.exs  my_app/config/prod.exs     my_app/config/test.exs  my_app/lib/my_app_web.ex
my_app/config/dev.exs     my_app/config/runtime.exs  my_app/lib/my_app.ex    my_app/test/test_helper.exs

with globstar:
my_app/config/config.exs                              my_app/lib/my_app_web/controllers/page_html.ex
my_app/config/dev.exs                                 my_app/lib/my_app_web/endpoint.ex
my_app/config/prod.exs                                my_app/lib/my_app_web.ex
my_app/config/runtime.exs                             my_app/lib/my_app_web/gettext.ex
my_app/config/test.exs                                my_app/lib/my_app_web/router.ex
my_app/lib/my_app/application.ex                      my_app/lib/my_app_web/telemetry.ex
my_app/lib/my_app.ex                                  my_app/mix.exs
my_app/lib/my_app/mailer.ex                           my_app/priv/repo/seeds.exs
my_app/lib/my_app/repo.ex                             my_app/test/my_app_web/controllers/error_html_test.exs
my_app/lib/my_app_web/components/core_components.ex   my_app/test/my_app_web/controllers/error_json_test.exs
my_app/lib/my_app_web/components/layouts.ex           my_app/test/my_app_web/controllers/page_controller_test.exs
my_app/lib/my_app_web/controllers/error_html.ex       my_app/test/support/conn_case.ex
my_app/lib/my_app_web/controllers/error_json.ex       my_app/test/support/data_case.ex
my_app/lib/my_app_web/controllers/page_controller.ex  my_app/test/test_helper.exs
```