### PR TITLE
Fix builds for phx.new 1.6.0-rc.1, 1.6.0-rc.0 and 1.3.5

### DIFF
--- a/lib/utility/project_builder.ex
+++ b/lib/utility/project_builder.ex
@@ -149,6 +149,15 @@ defmodule Utility.ProjectBuilder do
     |> String.trim()
   end
 
+  def install_archive("phx_new", "1.3.5") do
+    """
+    git clone https://github.com/phoenixframework/phoenix.git &&
+      (cd phoenix/installer && git checkout v1.3.5 && MIX_ENV=prod mix do deps.get, compile, archive.build, archive.install --force) &&
+      rm -rf phoenix
+    """
+    |> String.trim()
+  end
+
   def install_archive("phx_new", version_string) do
     version = Version.parse!(version_string)
 

--- a/lib/utility/project_builder.ex
+++ b/lib/utility/project_builder.ex
@@ -329,7 +329,7 @@ defmodule Utility.ProjectBuilder do
   end
 
   @phx_latest_at Version.parse!("1.7.0-rc.0")
-  @phx_112_at Version.parse!("1.6.0")
+  @phx_112_at Version.parse!("1.6.0-rc.0")
   @phx_111_at Version.parse!("1.3.0")
   def docker_tag_for("phx.new", "master"), do: "latest"
   def docker_tag_for("phx.new", "main"), do: "latest"


### PR DESCRIPTION
## 1.6.0-rc.1 and 1.6.0-rc.0

These versions require Elixir ~> 1.12

```shell
$ docker run -it --rm diff-builder:111 /bin/bash -c 'mix archive.install --force hex phx_new 1.6.0-rc.0'

Resolving Hex dependencies...
Resolution completed in 0.009s
New:
  phx_new 1.6.0-rc.0
* Getting phx_new (Hex package)
All dependencies are up to date
** (Mix) You're trying to run :phx_new on Elixir v1.11.1 but it has declared in its mix.exs file it supports only Elixir ~> 1.12
```

## 1.3.5

Fetching from <https://github.com/phoenixframework/phoenix.git> like `main` because it's not in <https://github.com/phoenixframework/archives/> and package from hex.pm doesn't compile:

```shell
$ docker run -it --rm diff-builder:111 /bin/bash -c 'mix archive.install --force hex phx_new 1.3.5'

Resolving Hex dependencies...
Resolution completed in 0.012s
New:
  phx_new 1.3.5
* Getting phx_new (Hex package)
All dependencies are up to date
Compiling 12 files (.ex)

== Compilation error in file lib/mix/tasks/phoenix.new.ex ==
** (File.Error) could not read file "/tmp/mix-local-installer-fetcher-fDPd7g/deps/priv/static/phoenix.js": no such file or directory
    (elixir 1.11.1) lib/file.ex:354: File.read!/1
    lib/mix/tasks/phoenix.new.ex:95: (module)
    (stdlib 3.14) erl_eval.erl:680: :erl_eval.do_apply/6
```
